### PR TITLE
feat: Makefile作成

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,101 @@
+.PHONY: help lint lint-fix test build clean open check ci
+
+# デフォルトターゲット
+.DEFAULT_GOAL := help
+
+# プロジェクト設定
+PROJECT = OldIPhoneCameraExperience.xcodeproj
+SCHEME = OldIPhoneCameraExperience
+SIMULATOR = platform=iOS Simulator,name=iPhone 16
+
+# ===== Lintチェック =====
+## SwiftLint実行
+lint:
+	@echo "Running SwiftLint..."
+	@swiftlint
+
+## SwiftLint自動修正
+lint-fix:
+	@echo "Running SwiftLint auto-fix..."
+	@swiftlint --fix
+	@echo ""
+	@echo "Running lint check after fix..."
+	@$(MAKE) lint
+
+# ===== テスト =====
+## ユニットテスト実行
+test:
+	@echo "Running tests..."
+	@xcodebuild test \
+		-project $(PROJECT) \
+		-scheme $(SCHEME) \
+		-destination '$(SIMULATOR)' \
+		-quiet
+
+# ===== ビルド =====
+## リリースビルド
+build:
+	@echo "Building release..."
+	@xcodebuild build \
+		-project $(PROJECT) \
+		-scheme $(SCHEME) \
+		-destination '$(SIMULATOR)' \
+		-configuration Release \
+		-quiet
+
+# ===== 開発支援 =====
+## DerivedDataクリア + ビルドキャッシュ削除
+clean:
+	@echo "Cleaning DerivedData..."
+	@xcodebuild clean \
+		-project $(PROJECT) \
+		-scheme $(SCHEME) \
+		-quiet
+	@rm -rf ~/Library/Developer/Xcode/DerivedData/$(SCHEME)-*
+	@echo "DerivedData cleaned."
+
+## Xcodeでプロジェクトを開く
+open:
+	@open $(PROJECT)
+
+# ===== 品質チェック =====
+## lint + test を一括実行
+check:
+	@echo "Running full check..."
+	@$(MAKE) lint
+	@echo ""
+	@$(MAKE) test
+
+## CI用全チェック(lint + test + build)
+ci:
+	@echo "Running CI pipeline..."
+	@$(MAKE) lint
+	@echo ""
+	@$(MAKE) test
+	@echo ""
+	@$(MAKE) build
+	@echo ""
+	@echo "CI pipeline completed!"
+
+# ===== ヘルプ =====
+## コマンド一覧表示
+help:
+	@echo "Available commands:"
+	@echo ""
+	@echo "  Lint:"
+	@echo "    make lint          - Run SwiftLint"
+	@echo "    make lint-fix      - Auto-fix SwiftLint issues"
+	@echo ""
+	@echo "  Test:"
+	@echo "    make test          - Run unit tests"
+	@echo ""
+	@echo "  Build:"
+	@echo "    make build         - Build release"
+	@echo ""
+	@echo "  Development:"
+	@echo "    make clean         - Clean DerivedData and build cache"
+	@echo "    make open          - Open project in Xcode"
+	@echo ""
+	@echo "  Quality:"
+	@echo "    make check         - Run lint + test"
+	@echo "    make ci            - Run full CI pipeline (lint + test + build)"


### PR DESCRIPTION
## 概要

開発で頻繁に使うコマンドをMakefileにまとめ、ショートカットとして実行できるようにする。
flutter_fast_starterのMakefile構成をSwift/Xcode向けに移植。

## 変更内容

- `Makefile` を新規作成（9コマンド定義）

| コマンド | 内容 |
|---------|------|
| `make help` | コマンド一覧表示（デフォルト） |
| `make lint` | SwiftLint実行 |
| `make lint-fix` | SwiftLint自動修正 |
| `make test` | xcodebuild test でユニットテスト実行 |
| `make build` | xcodebuild build でリリースビルド |
| `make clean` | DerivedDataクリア + ビルドキャッシュ削除 |
| `make open` | Xcodeでプロジェクトを開く |
| `make check` | lint + test を一括実行 |
| `make ci` | lint + test + build を一括実行 |

## テスト結果

| ID | テストケース | 結果 |
|----|-------------|------|
| T-4.1 | `make help` を実行する | コマンド一覧が正しく表示された |
| T-4.2 | `make lint` を実行する | SwiftLintが実行され 0 violations |
| T-4.3 | `make test` を実行する | xcodebuild testが実行された（テストターゲット未作成のためスキップ） |
| T-4.4 | `make check` を実行する | T-4.3と同様、テストターゲット追加後に完全動作 |
| T-4.5 | `make clean` を実行する | DerivedDataが削除された |
| T-4.6 | `make open` を実行する | コマンド定義済み（`open OldIPhoneCameraExperience.xcodeproj`） |

## 備考

- T-4.3, T-4.4 はテストターゲットが未作成のため `xcodebuild test` がエラーになるが、テストターゲット追加後に正常動作する想定
- シミュレータは `iPhone 16` を指定

Closes #4