### PR TITLE
fix: 不要なAVCaptureVideoDataOutputを削除しプレビューフリーズを解消

### DIFF
--- a/OldIPhoneCameraExperience/Services/CameraService.swift
+++ b/OldIPhoneCameraExperience/Services/CameraService.swift
@@ -65,7 +65,6 @@ final class CameraService: NSObject, CameraServiceProtocol {
     let captureSession = AVCaptureSession()
     private var currentDevice: AVCaptureDevice?
     private var photoOutput: AVCapturePhotoOutput?
-    private var videoDataOutput: AVCaptureVideoDataOutput?
     private var movieFileOutput: AVCaptureMovieFileOutput?
     private var audioInput: AVCaptureDeviceInput?
     private var currentPosition: AVCaptureDevice.Position = CameraConfig.defaultPosition
@@ -74,7 +73,6 @@ final class CameraService: NSObject, CameraServiceProtocol {
     private var flashMode: AVCaptureDevice.FlashMode = .off
     private var torchRequested: Bool = false
     private let sessionQueue = DispatchQueue(label: "com.oldiPhonecamera.sessionQueue")
-    private let videoDataOutputQueue = DispatchQueue(label: "com.oldiPhonecamera.videoDataOutput")
     private let zoomLock = NSLock()
     private var _currentZoomFactor: CGFloat = CameraConfig.minZoomFactor
 
@@ -156,13 +154,6 @@ final class CameraService: NSObject, CameraServiceProtocol {
         if captureSession.canAddOutput(photoOut) {
             captureSession.addOutput(photoOut)
             photoOutput = photoOut
-        }
-
-        let videoOut = AVCaptureVideoDataOutput()
-        videoOut.setSampleBufferDelegate(self, queue: videoDataOutputQueue)
-        if captureSession.canAddOutput(videoOut) {
-            captureSession.addOutput(videoOut)
-            videoDataOutput = videoOut
         }
 
         let movieOut = AVCaptureMovieFileOutput()
@@ -417,22 +408,6 @@ extension CameraService: AVCapturePhotoCaptureDelegate {
 
         photoContinuation?.resume(returning: orientedImage)
         photoContinuation = nil
-    }
-}
-
-// MARK: - AVCaptureVideoDataOutputSampleBufferDelegate
-
-extension CameraService: AVCaptureVideoDataOutputSampleBufferDelegate {
-    func captureOutput(
-        _: AVCaptureOutput,
-        didOutput sampleBuffer: CMSampleBuffer,
-        from _: AVCaptureConnection
-    ) {
-        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else {
-            return
-        }
-
-        _ = CIImage(cvPixelBuffer: pixelBuffer)
     }
 }
 


### PR DESCRIPTION
## Summary
- TestFlight（Release）環境でカメラプレビューが約4秒後にフリーズする問題を修正
- 原因: `AVCaptureVideoDataOutput`が毎フレーム処理を実行していたが、どの機能にも使用されていなかった
- `AVCaptureMovieFileOutput`との同時使用によるバッファ競合がRelease環境でのみフリーズを引き起こしていた
- 不要な`AVCaptureVideoDataOutput`関連コードを全削除（25行削除、追加なし）

## Test plan
- [ ] TestFlight（Release）でプレビューが4秒以上フリーズしないこと
- [ ] Debugモードでプレビューが軽くなっていること
- [ ] 写真撮影が正常に動作すること
- [ ] 動画録画が正常に動作すること
- [ ] カメラ切替が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)