### PR TITLE
feat: iPhone 6モード追加 — モデル切替ドロップダウン + フィルター/手ぶれ/解像度の差別化

### DIFF
--- a/OldIPhoneCameraExperience/Models/AspectRatio.swift
+++ b/OldIPhoneCameraExperience/Models/AspectRatio.swift
@@ -9,12 +9,6 @@ import CoreGraphics
 
 /// 写真撮影のアスペクト比（動画は16:9固定で切替不可）
 enum AspectRatio: CaseIterable {
-    /// iPhone 4 5MP相当の出力解像度（横持ち基準）
-    static let baseWidth = 2592
-    static let baseHeight = 1936
-    /// 16:9用の高さ（baseWidth × 9/16）
-    static let wideHeight = 1458
-
     /// 1:1（Instagram等のSNS投稿用）
     case square
 
@@ -53,24 +47,6 @@ enum AspectRatio: CaseIterable {
         case .square: "1:1"
         case .standard: "4:3"
         case .wide: "16:9"
-        }
-    }
-
-    /// 出力画像の幅（横持ち基準、px）
-    var outputWidth: Int {
-        switch self {
-        case .square: Self.baseHeight
-        case .standard: Self.baseWidth
-        case .wide: Self.baseWidth
-        }
-    }
-
-    /// 出力画像の高さ（横持ち基準、px）
-    var outputHeight: Int {
-        switch self {
-        case .square: Self.baseHeight
-        case .standard: Self.baseHeight
-        case .wide: Self.wideHeight
         }
     }
 

--- a/OldIPhoneCameraExperience/Models/CameraModel.swift
+++ b/OldIPhoneCameraExperience/Models/CameraModel.swift
@@ -45,8 +45,20 @@ extension CameraModel {
         isFree: true
     )
 
-    /// すべての機種一覧（Phase 2で拡張予定）
+    /// iPhone 6 のプリセット
+    static let iPhone6 = CameraModel(
+        name: "iPhone 6",
+        era: "iOS 8",
+        year: 2014,
+        megapixels: 8.0,
+        focalLength: 29.0,
+        filterConfig: .iPhone6,
+        isFree: true
+    )
+
+    /// すべての機種一覧
     static let allModels: [CameraModel] = [
-        .iPhone4
+        .iPhone4,
+        .iPhone6,
     ]
 }

--- a/OldIPhoneCameraExperience/Models/FilterConfig.swift
+++ b/OldIPhoneCameraExperience/Models/FilterConfig.swift
@@ -32,14 +32,41 @@ struct FilterConfig: Equatable {
     /// アスペクト比（デフォルト: 4:3）
     let aspectRatio: AspectRatio
 
-    /// 出力画像の幅（px）— アスペクト比から自動計算
+    // MARK: - 手ブレシミュレーション（F2.3）
+
+    /// X/Y方向のシフト量範囲（px）
+    let shakeShiftRange: ClosedRange<Double>
+
+    /// 回転角度範囲（度）
+    let shakeRotationRange: ClosedRange<Double>
+
+    /// モーションブラー半径範囲
+    let motionBlurRadiusRange: ClosedRange<Double>
+
+    // MARK: - 出力解像度
+
+    /// 基準幅（横持ち基準、px）
+    let baseWidth: Int
+
+    /// 基準高さ（横持ち基準、px）
+    let baseHeight: Int
+
+    /// 出力画像の幅（px）— アスペクト比と基準解像度から算出
     var outputWidth: Int {
-        aspectRatio.outputWidth
+        switch aspectRatio {
+        case .square: baseHeight
+        case .standard: baseWidth
+        case .wide: baseWidth
+        }
     }
 
-    /// 出力画像の高さ（px）— アスペクト比から自動計算
+    /// 出力画像の高さ（px）— アスペクト比と基準解像度から算出
     var outputHeight: Int {
-        aspectRatio.outputHeight
+        switch aspectRatio {
+        case .square: baseHeight
+        case .standard: baseHeight
+        case .wide: baseWidth * 9 / 16
+        }
     }
 
     init(
@@ -48,7 +75,12 @@ struct FilterConfig: Equatable {
         saturation: Double,
         highlightTintIntensity: Double,
         cropRatio: Double,
-        aspectRatio: AspectRatio = .standard
+        aspectRatio: AspectRatio = .standard,
+        shakeShiftRange: ClosedRange<Double> = 1.0 ... 5.0,
+        shakeRotationRange: ClosedRange<Double> = -0.5 ... 0.5,
+        motionBlurRadiusRange: ClosedRange<Double> = 1.0 ... 3.0,
+        baseWidth: Int = 2592,
+        baseHeight: Int = 1936
     ) {
         self.warmth = warmth
         self.tint = tint
@@ -56,6 +88,11 @@ struct FilterConfig: Equatable {
         self.highlightTintIntensity = highlightTintIntensity
         self.cropRatio = cropRatio
         self.aspectRatio = aspectRatio
+        self.shakeShiftRange = shakeShiftRange
+        self.shakeRotationRange = shakeRotationRange
+        self.motionBlurRadiusRange = motionBlurRadiusRange
+        self.baseWidth = baseWidth
+        self.baseHeight = baseHeight
     }
 }
 
@@ -68,6 +105,25 @@ extension FilterConfig {
         tint: 10,
         saturation: Double(FilterParameters.saturation),
         highlightTintIntensity: Double(FilterParameters.highlightTintAmount),
-        cropRatio: Double(FilterParameters.cropRatio)
+        cropRatio: Double(FilterParameters.cropRatio),
+        shakeShiftRange: FilterParameters.shakeShiftRange,
+        shakeRotationRange: FilterParameters.shakeRotationRange,
+        motionBlurRadiusRange: FilterParameters.motionBlurRadiusRange,
+        baseWidth: FilterParameters.outputWidth,
+        baseHeight: FilterParameters.outputHeight
+    )
+
+    /// iPhone 6 のフィルター設定
+    static let iPhone6 = FilterConfig(
+        warmth: 500,
+        tint: 5,
+        saturation: 0.95,
+        highlightTintIntensity: 0.05,
+        cropRatio: 0.87,
+        shakeShiftRange: 0.5 ... 2.5,
+        shakeRotationRange: -0.25 ... 0.25,
+        motionBlurRadiusRange: 0.5 ... 1.5,
+        baseWidth: 3264,
+        baseHeight: 2448
     )
 }

--- a/OldIPhoneCameraExperience/Models/FilterConfig.swift
+++ b/OldIPhoneCameraExperience/Models/FilterConfig.swift
@@ -100,17 +100,13 @@ struct FilterConfig: Equatable {
 
 extension FilterConfig {
     /// iPhone 4 のフィルター設定（MVP）
+    /// 手ブレ・解像度パラメータはinitのデフォルト値（iPhone 4相当）を使用
     static let iPhone4 = FilterConfig(
         warmth: Double(FilterParameters.warmthShift),
         tint: 10,
         saturation: Double(FilterParameters.saturation),
         highlightTintIntensity: Double(FilterParameters.highlightTintAmount),
-        cropRatio: Double(FilterParameters.cropRatio),
-        shakeShiftRange: FilterParameters.shakeShiftRange,
-        shakeRotationRange: FilterParameters.shakeRotationRange,
-        motionBlurRadiusRange: FilterParameters.motionBlurRadiusRange,
-        baseWidth: FilterParameters.outputWidth,
-        baseHeight: FilterParameters.outputHeight
+        cropRatio: Double(FilterParameters.cropRatio)
     )
 
     /// iPhone 6 のフィルター設定

--- a/OldIPhoneCameraExperience/Models/ShakeEffect.swift
+++ b/OldIPhoneCameraExperience/Models/ShakeEffect.swift
@@ -30,12 +30,14 @@ struct ShakeEffect: Equatable {
 
 extension ShakeEffect {
     /// ジャイロスコープのデータからShakeEffectを生成する
-    /// - Parameter deviceMotion: CoreMotionから取得したデバイスの動き（nilの場合はランダム生成）
+    /// - Parameters:
+    ///   - deviceMotion: CoreMotionから取得したデバイスの動き（nilの場合はランダム生成）
+    ///   - config: フィルター設定（手ブレパラメータを含む）
     /// - Returns: ランダム要素を含む手ブレパラメータ
-    static func generate(from deviceMotion: CMDeviceMotion?) -> ShakeEffect {
-        let shiftRange = FilterParameters.shakeShiftRange
-        let rotationRange = FilterParameters.shakeRotationRange
-        let blurRange = FilterParameters.motionBlurRadiusRange
+    static func generate(from deviceMotion: CMDeviceMotion?, config: FilterConfig) -> ShakeEffect {
+        let shiftRange = config.shakeShiftRange
+        let rotationRange = config.shakeRotationRange
+        let blurRange = config.motionBlurRadiusRange
 
         let shiftX = Double.random(in: shiftRange)
         let shiftY = Double.random(in: shiftRange)

--- a/OldIPhoneCameraExperience/ViewModels/CameraViewModel.swift
+++ b/OldIPhoneCameraExperience/ViewModels/CameraViewModel.swift
@@ -40,7 +40,7 @@ final class CameraViewModel: ObservableObject {
 
     // MARK: - Private Properties
 
-    private let currentModel: CameraModel = .iPhone4
+    @Published private(set) var currentModel: CameraModel = .iPhone4
     private let ciContext = CIContext()
     private var recordingTimer: AnyCancellable?
 
@@ -119,6 +119,14 @@ final class CameraViewModel: ObservableObject {
     /// 前面カメラ時はフラッシュボタンを非表示にする
     var shouldHideFlashButton: Bool {
         state.cameraPosition == .front
+    }
+
+    // MARK: - Model Selection
+
+    /// カメラモデルを切り替える（録画中は無効）
+    func selectModel(_ model: CameraModel) {
+        guard !isRecording else { return }
+        currentModel = model
     }
 
     // MARK: - Aspect Ratio
@@ -201,7 +209,7 @@ final class CameraViewModel: ObservableObject {
             }
 
             let motion = motionService.getCurrentMotion()
-            let shakeEffect = ShakeEffect.generate(from: motion)
+            let shakeEffect = ShakeEffect.generate(from: motion, config: config)
             let finalImage = filterService.applyShakeEffect(filteredImage, effect: shakeEffect) ?? filteredImage
 
             guard let uiImage = convertToUIImage(finalImage) else {
@@ -228,7 +236,12 @@ final class CameraViewModel: ObservableObject {
             saturation: base.saturation,
             highlightTintIntensity: base.highlightTintIntensity,
             cropRatio: base.cropRatio,
-            aspectRatio: aspectRatio
+            aspectRatio: aspectRatio,
+            shakeShiftRange: base.shakeShiftRange,
+            shakeRotationRange: base.shakeRotationRange,
+            motionBlurRadiusRange: base.motionBlurRadiusRange,
+            baseWidth: base.baseWidth,
+            baseHeight: base.baseHeight
         )
     }
 

--- a/OldIPhoneCameraExperience/Views/CameraScreen.swift
+++ b/OldIPhoneCameraExperience/Views/CameraScreen.swift
@@ -193,6 +193,12 @@ struct CameraScreen: View {
 
             Spacer()
 
+            modelSelector
+                .disabled(viewModel.isRecording)
+                .opacity(viewModel.isRecording ? 0.4 : 1.0)
+
+            Spacer()
+
             if !viewModel.shouldHideFlashButton {
                 ToolbarButton(
                     icon: viewModel.flashIconName,
@@ -205,6 +211,39 @@ struct CameraScreen: View {
             }
         }
         .background(viewModel.captureMode == .photo ? Color.black : Color.clear)
+    }
+
+    // MARK: - Model Selector
+
+    private var modelSelector: some View {
+        Menu {
+            ForEach(CameraModel.allModels, id: \.name) { model in
+                Button {
+                    viewModel.selectModel(model)
+                } label: {
+                    if model == viewModel.currentModel {
+                        Label(model.name, systemImage: "checkmark")
+                    } else {
+                        Text(model.name)
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Text(viewModel.currentModel.name)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(.white)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(.white.opacity(0.7))
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(
+                Capsule()
+                    .fill(Color.white.opacity(0.15))
+            )
+        }
     }
 
     // MARK: - Video Info Badges

--- a/OldIPhoneCameraExperienceTests/Models/CameraModelTests.swift
+++ b/OldIPhoneCameraExperienceTests/Models/CameraModelTests.swift
@@ -37,4 +37,26 @@ final class CameraModelTests: XCTestCase {
             "iPhone 4のfilterConfigはFilterConfig.iPhone4と一致する必要があります"
         )
     }
+
+    // MARK: - iPhone 6 プリセットテスト
+
+    func test_iPhone6_name() {
+        XCTAssertEqual(CameraModel.iPhone6.name, "iPhone 6")
+    }
+
+    func test_iPhone6_isFree() {
+        XCTAssertTrue(CameraModel.iPhone6.isFree)
+    }
+
+    func test_iPhone6_filterConfig_matchesPreset() {
+        XCTAssertEqual(CameraModel.iPhone6.filterConfig, FilterConfig.iPhone6)
+    }
+
+    // MARK: - allModels テスト
+
+    func test_allModels_containsBothModels() {
+        XCTAssertEqual(CameraModel.allModels.count, 2)
+        XCTAssertTrue(CameraModel.allModels.contains(.iPhone4))
+        XCTAssertTrue(CameraModel.allModels.contains(.iPhone6))
+    }
 }

--- a/OldIPhoneCameraExperienceTests/Models/FilterConfigTests.swift
+++ b/OldIPhoneCameraExperienceTests/Models/FilterConfigTests.swift
@@ -77,4 +77,91 @@ final class FilterConfigTests: XCTestCase {
             "アスペクト比は4:3である必要があります"
         )
     }
+
+    // MARK: - iPhone 6 プリセットテスト
+
+    func test_iPhone6_warmth_isLessThanIPhone4() {
+        XCTAssertGreaterThan(
+            FilterConfig.iPhone6.warmth,
+            0,
+            "iPhone 6の色温度は暖色方向（正の値）である必要があります"
+        )
+        XCTAssertLessThan(
+            FilterConfig.iPhone6.warmth,
+            FilterConfig.iPhone4.warmth,
+            "iPhone 6の色温度はiPhone 4より低い（より自然）必要があります"
+        )
+    }
+
+    func test_iPhone6_saturation_isHigherThanIPhone4() {
+        XCTAssertGreaterThan(
+            FilterConfig.iPhone6.saturation,
+            FilterConfig.iPhone4.saturation,
+            "iPhone 6の彩度はiPhone 4より高い必要があります"
+        )
+        XCTAssertLessThan(
+            FilterConfig.iPhone6.saturation,
+            1.0,
+            "iPhone 6の彩度は標準（1.0）より低い必要があります"
+        )
+    }
+
+    func test_iPhone6_resolution_is8MP() {
+        let width = FilterConfig.iPhone6.outputWidth
+        let height = FilterConfig.iPhone6.outputHeight
+
+        XCTAssertEqual(width, 3264, "幅は3264pxである必要があります")
+        XCTAssertEqual(height, 2448, "高さは2448pxである必要があります")
+
+        let megapixels = Double(width * height) / 1_000_000
+        XCTAssertEqual(megapixels, 8.0, accuracy: 0.1, "解像度は約8MP（800万画素）である必要があります")
+    }
+
+    func test_iPhone6_cropRatio_isWithinRange() {
+        XCTAssertGreaterThan(FilterConfig.iPhone6.cropRatio, 0)
+        XCTAssertLessThan(FilterConfig.iPhone6.cropRatio, 1)
+        XCTAssertGreaterThan(
+            FilterConfig.iPhone6.cropRatio,
+            FilterConfig.iPhone4.cropRatio,
+            "iPhone 6のクロップ率はiPhone 4より大きい（より広角）必要があります"
+        )
+    }
+
+    func test_iPhone6_shake_isSmallerThanIPhone4() {
+        let ip6 = FilterConfig.iPhone6
+        let ip4 = FilterConfig.iPhone4
+
+        XCTAssertLessThan(
+            ip6.shakeShiftRange.upperBound,
+            ip4.shakeShiftRange.upperBound,
+            "iPhone 6の手ぶれシフト範囲はiPhone 4より小さい必要があります"
+        )
+        XCTAssertLessThan(
+            ip6.motionBlurRadiusRange.upperBound,
+            ip4.motionBlurRadiusRange.upperBound,
+            "iPhone 6のモーションブラー範囲はiPhone 4より小さい必要があります"
+        )
+    }
+
+    func test_iPhone6_outputResolution_forSquare() {
+        let config = FilterConfig(
+            warmth: 500, tint: 5, saturation: 0.95,
+            highlightTintIntensity: 0.05, cropRatio: 0.87,
+            aspectRatio: .square,
+            baseWidth: 3264, baseHeight: 2448
+        )
+        XCTAssertEqual(config.outputWidth, 2448)
+        XCTAssertEqual(config.outputHeight, 2448)
+    }
+
+    func test_iPhone6_outputResolution_forWide() {
+        let config = FilterConfig(
+            warmth: 500, tint: 5, saturation: 0.95,
+            highlightTintIntensity: 0.05, cropRatio: 0.87,
+            aspectRatio: .wide,
+            baseWidth: 3264, baseHeight: 2448
+        )
+        XCTAssertEqual(config.outputWidth, 3264)
+        XCTAssertEqual(config.outputHeight, 3264 * 9 / 16)
+    }
 }

--- a/OldIPhoneCameraExperienceTests/Models/ShakeEffectTests.swift
+++ b/OldIPhoneCameraExperienceTests/Models/ShakeEffectTests.swift
@@ -31,7 +31,7 @@ final class ShakeEffectTests: XCTestCase {
     // MARK: - M-SE2: generateメソッドでShakeEffectが生成されること
 
     func test_generate_returnsNonNilEffect() {
-        let effect = ShakeEffect.generate(from: nil)
+        let effect = ShakeEffect.generate(from: nil, config: .iPhone4)
 
         XCTAssertNotNil(effect, "generateメソッドはShakeEffectを生成する必要があります")
     }
@@ -39,32 +39,32 @@ final class ShakeEffectTests: XCTestCase {
     // MARK: - M-SE3: shiftX/shiftYが範囲内であること
 
     func test_generate_shiftValues_areWithinRange() {
-        let effect = ShakeEffect.generate(from: nil)
-        let range = FilterParameters.shakeShiftRange
+        let config = FilterConfig.iPhone4
+        let effect = ShakeEffect.generate(from: nil, config: config)
 
-        XCTAssertGreaterThanOrEqual(effect.shiftX, Double(range.lowerBound))
-        XCTAssertLessThanOrEqual(effect.shiftX, Double(range.upperBound))
-        XCTAssertGreaterThanOrEqual(effect.shiftY, Double(range.lowerBound))
-        XCTAssertLessThanOrEqual(effect.shiftY, Double(range.upperBound))
+        XCTAssertGreaterThanOrEqual(effect.shiftX, config.shakeShiftRange.lowerBound)
+        XCTAssertLessThanOrEqual(effect.shiftX, config.shakeShiftRange.upperBound)
+        XCTAssertGreaterThanOrEqual(effect.shiftY, config.shakeShiftRange.lowerBound)
+        XCTAssertLessThanOrEqual(effect.shiftY, config.shakeShiftRange.upperBound)
     }
 
     // MARK: - M-SE4: rotationが範囲内であること
 
     func test_generate_rotation_isWithinRange() {
-        let effect = ShakeEffect.generate(from: nil)
-        let range = FilterParameters.shakeRotationRange
+        let config = FilterConfig.iPhone4
+        let effect = ShakeEffect.generate(from: nil, config: config)
 
-        XCTAssertGreaterThanOrEqual(effect.rotation, Double(range.lowerBound))
-        XCTAssertLessThanOrEqual(effect.rotation, Double(range.upperBound))
+        XCTAssertGreaterThanOrEqual(effect.rotation, config.shakeRotationRange.lowerBound)
+        XCTAssertLessThanOrEqual(effect.rotation, config.shakeRotationRange.upperBound)
     }
 
     // MARK: - M-SE5: motionBlurRadiusが範囲内であること
 
     func test_generate_motionBlurRadius_isWithinRange() {
-        let effect = ShakeEffect.generate(from: nil)
-        let range = FilterParameters.motionBlurRadiusRange
+        let config = FilterConfig.iPhone4
+        let effect = ShakeEffect.generate(from: nil, config: config)
 
-        XCTAssertGreaterThanOrEqual(effect.motionBlurRadius, Double(range.lowerBound))
-        XCTAssertLessThanOrEqual(effect.motionBlurRadius, Double(range.upperBound))
+        XCTAssertGreaterThanOrEqual(effect.motionBlurRadius, config.motionBlurRadiusRange.lowerBound)
+        XCTAssertLessThanOrEqual(effect.motionBlurRadius, config.motionBlurRadiusRange.upperBound)
     }
 }

--- a/OldIPhoneCameraExperienceTests/Models/ShakeEffectTests.swift
+++ b/OldIPhoneCameraExperienceTests/Models/ShakeEffectTests.swift
@@ -67,4 +67,24 @@ final class ShakeEffectTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(effect.motionBlurRadius, config.motionBlurRadiusRange.lowerBound)
         XCTAssertLessThanOrEqual(effect.motionBlurRadius, config.motionBlurRadiusRange.upperBound)
     }
+
+    // MARK: - iPhone 6 手ぶれ範囲テスト
+
+    func test_generate_iPhone6_shiftValues_areWithinRange() {
+        let config = FilterConfig.iPhone6
+        let effect = ShakeEffect.generate(from: nil, config: config)
+
+        XCTAssertGreaterThanOrEqual(effect.shiftX, config.shakeShiftRange.lowerBound)
+        XCTAssertLessThanOrEqual(effect.shiftX, config.shakeShiftRange.upperBound)
+        XCTAssertGreaterThanOrEqual(effect.shiftY, config.shakeShiftRange.lowerBound)
+        XCTAssertLessThanOrEqual(effect.shiftY, config.shakeShiftRange.upperBound)
+    }
+
+    func test_generate_iPhone6_motionBlurRadius_isWithinRange() {
+        let config = FilterConfig.iPhone6
+        let effect = ShakeEffect.generate(from: nil, config: config)
+
+        XCTAssertGreaterThanOrEqual(effect.motionBlurRadius, config.motionBlurRadiusRange.lowerBound)
+        XCTAssertLessThanOrEqual(effect.motionBlurRadius, config.motionBlurRadiusRange.upperBound)
+    }
 }

--- a/OldIPhoneCameraExperienceTests/ViewModels/CameraViewModelTests.swift
+++ b/OldIPhoneCameraExperienceTests/ViewModels/CameraViewModelTests.swift
@@ -182,4 +182,25 @@ final class CameraViewModelTests: XCTestCase {
             XCTAssertEqual(sut.state.permissionStatus, .denied, "権限拒否時にpermissionStatusが.deniedになる必要があります")
         }
     }
+
+    // MARK: - モデル切替テスト
+
+    func test_initialModel_isIPhone4() {
+        XCTAssertEqual(sut.currentModel, .iPhone4, "初期モデルはiPhone 4である必要があります")
+    }
+
+    func test_selectModel_changesToIPhone6() {
+        sut.selectModel(.iPhone6)
+
+        XCTAssertEqual(sut.currentModel, .iPhone6, "selectModel後はiPhone 6に切り替わる必要があります")
+    }
+
+    func test_selectModel_duringRecording_isBlocked() {
+        sut.switchToVideoMode()
+        sut.startRecording()
+
+        sut.selectModel(.iPhone6)
+
+        XCTAssertEqual(sut.currentModel, .iPhone4, "録画中はモデル切替が無効化される必要があります")
+    }
 }


### PR DESCRIPTION
## Summary

- iPhone 6モードを追加し、TopToolbar中央のドロップダウンメニューでiPhone 4/iPhone 6を切り替え可能に
- FilterConfigに手ぶれパラメータ（shakeShiftRange等）と出力解像度（baseWidth/baseHeight）を集約し、モデルごとにパラメータを差別化
- iPhone 6フィルター: iPhone 4より自然な色味（暖色控えめ）、手ぶれ半減、8MP出力

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `Models/FilterConfig.swift` | 手ぶれ・解像度パラメータ追加 + iPhone 6プリセット |
| `Models/AspectRatio.swift` | ハードコード解像度定数を削除（FilterConfigに移行） |
| `Models/ShakeEffect.swift` | `generate(from:config:)` でFilterConfigの手ぶれパラメータを使用 |
| `Models/CameraModel.swift` | iPhone 6モデル定義追加 |
| `ViewModels/CameraViewModel.swift` | `currentModel`を`@Published`に変更 + `selectModel(_:)`追加 |
| `Views/CameraScreen.swift` | TopToolbar中央にMenuベースのモデル選択UI追加 |
| `Tests/ShakeEffectTests.swift` | 新シグネチャ対応 |

## Test plan

- [ ] iPhone 4モードで写真撮影 → 従来通りの色味・手ぶれ・5MP解像度で保存される
- [ ] iPhone 6モードで写真撮影 → より自然な色味・少ない手ぶれ・8MP解像度で保存される
- [ ] iPhone 4モードで動画録画 → 従来通りの色味で保存される
- [ ] iPhone 6モードで動画録画 → より自然な色味で保存される
- [ ] ドロップダウンでモデル切替ができる
- [ ] 録画中はモデル切替が無効になる
- [ ] モデル切替後にアスペクト比変更が正しく動作する
- [ ] 既存テスト（ShakeEffectTests, FilterConfigTests等）がパスする

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)